### PR TITLE
#17 fix: import cstdint

### DIFF
--- a/src/wwtools/bnk.cpp
+++ b/src/wwtools/bnk.cpp
@@ -1,6 +1,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include "kaitai/kaitaistream.h"
 #include "kaitai/structs/bnk.h"


### PR DESCRIPTION
My system couldn't find `std::uint32_t` without importing this. I'm still slightly confused because apparently this wasn't necessary for some other users, and so I hope this doesn't potentially break anyone else's compilation.