### PR TITLE
Build both Intel and ARM64 for macOS

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           submodules: true
 

--- a/.github/workflows/doxygen-publish.yml
+++ b/.github/workflows/doxygen-publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -21,7 +21,7 @@ jobs:
       - name: Build
         run: cmake --build build
         
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: Linux Release
           path: |
@@ -44,7 +44,7 @@ jobs:
       - name: Build
         run: cmake --build build --config Release
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: Windows Release
           # For some reason the dynamic lib is in the bin directory
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v5
       - name: List stuff
         run: ls -R
       - name: Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,8 @@ set_target_properties(wwtools-bin PROPERTIES OUTPUT_NAME wwtools)
 set_target_properties(wwtools-shared-lib PROPERTIES OUTPUT_NAME wwtools)
 set_target_properties(wwtools-static-lib PROPERTIES OUTPUT_NAME wwtools)
 
+target_compile_definitions(wwtools-shared-lib PRIVATE WWTOOLS_LIBRARY)
+
 # Standard filesystem library needs additional linking options on older compilers
 # https://en.cppreference.com/w/cpp/filesystem#Notes
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,12 @@ else()
   target_link_libraries(wwtools-bin ogg vorbis)
 endif()
 
+if(APPLE)
+# Do a strip, the files are pretty large on macOS
+# set(CMAKE_INSTALL_DO_STRIP TRUE)
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,-x")
+endif()
+
 # To install to the default location, destination directive is unnecessary
 # https://cmake.org/cmake/help/latest/command/install.html#installing-targets
 install(TARGETS wwtools-bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/lib")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+if(APPLE)
+set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
+endif()
+
 include_directories(
     include
     libogg/include

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,3 @@
 # Build for macOS
-rm -rf build obj && mkdir build && mkdir obj && (cd build && cmake .. && make)
+rm -rf build obj && mkdir build && mkdir obj && cmake -DCMAKE_BUILD_TYPE=Release -S . -B build && \
+	cmake --build build -- -j`sysctl -n hw.logicalcpu`

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+# Build for macOS
+rm -rf build obj && mkdir build && mkdir obj && (cd build && cmake .. && make)

--- a/include/export.h
+++ b/include/export.h
@@ -3,10 +3,8 @@
 
 #if defined(_WIN32) && defined(WWTOOLS_LIBRARY)
 #   define WWTOOLS_EXPORT __declspec(dllexport)
-#   define WWTOOLS_CALL __cdecl
 #else
 #   define WWTOOLS_EXPORT
-#   define WWTOOLS_CALL
 #endif
 
 #endif //WWISE_AUDIO_TOOLS_EXPORT_H

--- a/include/export.h
+++ b/include/export.h
@@ -1,0 +1,12 @@
+#ifndef WWISE_AUDIO_TOOLS_EXPORT_H
+#define WWISE_AUDIO_TOOLS_EXPORT_H
+
+#if defined(_WIN32) && defined(WWTOOLS_LIBRARY)
+#   define WWTOOLS_EXPORT __declspec(dllexport)
+#   define WWTOOLS_CALL __cdecl
+#else
+#   define WWTOOLS_EXPORT
+#   define WWTOOLS_CALL
+#endif
+
+#endif //WWISE_AUDIO_TOOLS_EXPORT_H

--- a/include/wwtools/wwtools.hpp
+++ b/include/wwtools/wwtools.hpp
@@ -31,9 +31,9 @@ std::string wem_to_ogg(const std::string &indata);
 
 #if WWTOOLS_LIBRARY
 extern "C" {
-WWTOOLS_EXPORT uint64_t WWTOOLS_CALL get_wem_to_ogg_size(const uint8_t *indata, uint64_t insize);
+WWTOOLS_EXPORT uint64_t get_wem_to_ogg_size(const uint8_t *indata, uint64_t insize);
 
-WWTOOLS_EXPORT void WWTOOLS_CALL wem_to_ogg(const uint8_t *indata, uint64_t insize, uint8_t *outdata);
+WWTOOLS_EXPORT void wem_to_ogg(const uint8_t *indata, uint64_t insize, uint8_t *outdata);
 }
 #endif
 } // namespace wwtools

--- a/include/wwtools/wwtools.hpp
+++ b/include/wwtools/wwtools.hpp
@@ -26,6 +26,12 @@ namespace wwtools {
  * @return OGG file data
  */
 std::string wem_to_ogg(const std::string &indata);
+
+extern "C" {
+__declspec(dllexport) uint64_t __cdecl get_wem_to_ogg_size(const uint8_t *indata, uint64_t insize);
+
+__declspec(dllexport) void __cdecl wem_to_ogg(const uint8_t *indata, uint64_t insize, uint8_t *outdata);
+}
 } // namespace wwtools
 
 #endif // WWTOOLS_WWTOOLS_HPP

--- a/include/wwtools/wwtools.hpp
+++ b/include/wwtools/wwtools.hpp
@@ -13,6 +13,8 @@
 
 #include <string>
 
+#include "export.h"
+
 /**
  * @namespace wwtools
  * @brief parent namespace for specific file type helper functions
@@ -27,11 +29,13 @@ namespace wwtools {
  */
 std::string wem_to_ogg(const std::string &indata);
 
+#if WWTOOLS_LIBRARY
 extern "C" {
-__declspec(dllexport) uint64_t __cdecl get_wem_to_ogg_size(const uint8_t *indata, uint64_t insize);
+WWTOOLS_EXPORT uint64_t WWTOOLS_CALL get_wem_to_ogg_size(const uint8_t *indata, uint64_t insize);
 
-__declspec(dllexport) void __cdecl wem_to_ogg(const uint8_t *indata, uint64_t insize, uint8_t *outdata);
+WWTOOLS_EXPORT void WWTOOLS_CALL wem_to_ogg(const uint8_t *indata, uint64_t insize, uint8_t *outdata);
 }
+#endif
 } // namespace wwtools
 
 #endif // WWTOOLS_WWTOOLS_HPP

--- a/src/wwtools/wwtools.cpp
+++ b/src/wwtools/wwtools.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <string>
 
 #include "revorb/revorb.hpp"
@@ -29,7 +30,7 @@ uint64_t get_wem_to_ogg_size(const uint8_t* indata, uint64_t insize) {
 void wem_to_ogg(const uint8_t *indata, uint64_t insize, uint8_t *outdata) {
   const auto wem = std::string(reinterpret_cast<const char*>(indata), insize);
   const std::string ogg = wem_to_ogg(wem);
-  std::memcpy(outdata, ogg.data(), ogg.size());
+  std::copy_n(reinterpret_cast<const uint8_t*>(ogg.data()), ogg.size(), outdata);
 }
 
 } // namespace wwtools

--- a/src/wwtools/wwtools.cpp
+++ b/src/wwtools/wwtools.cpp
@@ -29,7 +29,7 @@ uint64_t get_wem_to_ogg_size(const uint8_t* indata, uint64_t insize) {
 void wem_to_ogg(const uint8_t *indata, uint64_t insize, uint8_t *outdata) {
   const auto wem = std::string(reinterpret_cast<const char*>(indata), insize);
   const std::string ogg = wem_to_ogg(wem);
-  std::copy_n(reinterpret_cast<const uint8_t*>(ogg.data()), ogg.size(), outdata);
+  std::memcpy(outdata, ogg.data(), ogg.size());
 }
 
 } // namespace wwtools

--- a/src/wwtools/wwtools.cpp
+++ b/src/wwtools/wwtools.cpp
@@ -19,4 +19,17 @@ std::string wem_to_ogg(const std::string &indata) {
 
   return revorb_out.str();
 }
+
+uint64_t get_wem_to_ogg_size(const uint8_t* indata, uint64_t insize) {
+  const auto wem = std::string(reinterpret_cast<const char*>(indata), insize);
+  const std::string ogg = wem_to_ogg(wem);
+  return ogg.size();
+}
+
+void wem_to_ogg(const uint8_t *indata, uint64_t insize, uint8_t *outdata) {
+  const auto wem = std::string(reinterpret_cast<const char*>(indata), insize);
+  const std::string ogg = wem_to_ogg(wem);
+  std::copy_n(reinterpret_cast<const uint8_t*>(ogg.data()), ogg.size(), outdata);
+}
+
 } // namespace wwtools


### PR DESCRIPTION
Simple Cmake change to enable universal build on macOS. Also included a build.sh for macOS.